### PR TITLE
Draft a specification

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -2,6 +2,8 @@
 
 The `plugins.yaml` file contains a list of objects, each representing a plug-in.
 
+YAML has been chosen because of its good readability while still being machine-readable and reasonably widespread. Compatibility with other formats is achieved through the CI, which converts the YAML file to other formats.
+
 ### Plug-Ins
 
 A Plug-In object consists of the following key-value pairs:

--- a/Specification.md
+++ b/Specification.md
@@ -1,0 +1,15 @@
+### plugins.yaml
+
+The `plugins.yaml` file contains a list of objects, each representing a plug-in.
+
+### Plug-Ins
+
+A Plug-In object consists of the following key-value pairs:
+
+- `name`
+- `url`: A link to the project's github repository.
+- `version`: Preferrably the name of a git tag, or a commit hash.
+- `author`: The author(s) of the plug-in.
+- `iconUrl` (optional): A direct URL to an image that is used as thumbnail. If possible, the image should be 160x160 pixels large.
+- `description`: A short-to-medium length description, similar to the plug-in's `about.txt`.
+

--- a/Specification.md
+++ b/Specification.md
@@ -8,7 +8,7 @@ A Plug-In object consists of the following key-value pairs:
 
 - `name`
 - `url`: A link to the project's github repository.
-- `version`: Preferrably the name of a git tag, or a commit hash.
+- `version`: Preferably the name of a git tag, or a commit hash.
 - `author`: The author(s) of the plug-in.
 - `iconUrl` (optional): A direct URL to an image that is used as thumbnail. If possible, the image should be 160x160 pixels large.
 - `description`: A short-to-medium length description, similar to the plug-in's `about.txt`.


### PR DESCRIPTION
Adds a specification for `plugins.yaml`. This should serve as a starting point to new contributors, as well as a guarantee to anyone relying on the document's consistency (eventually™).

I did not include the requirement for a license (#19) - I expect this specification to change in the future, but it could be included in this version already.