### PR TITLE
Bugfix upgrading Lampyrid plugin

### DIFF
--- a/manifests/Z Lampyrid Start.yaml
+++ b/manifests/Z Lampyrid Start.yaml
@@ -16,5 +16,6 @@ url: https://github.com/Zitchas/ES_Lampyrid_Start/releases/download/v1.6/Z_Lampy
 iconUrl: https://raw.githubusercontent.com/Zitchas/ES_Lampyrid_Start/v1.6/icon.png
 autoupdate:
   type: tag
+  url: https://github.com/Zitchas/ES_Lampyrid_Start/releases/download/$version/Z_Lampyrid_Start.release.$version.zip
   update_url: https://github.com/Zitchas/ES_Lampyrid_Start
   iconUrl: https://raw.githubusercontent.com/Zitchas/ES_Lampyrid_Start/$version/icon.png

--- a/manifests/Z Lampyrid Start.yaml
+++ b/manifests/Z Lampyrid Start.yaml
@@ -3,11 +3,18 @@ authors: Zitchas
 homepage: https://github.com/Zitchas/ES_Lampyrid_Start
 license: GPL-3.0-or-later
 version: v1.6
-shortDescription: Enables an alternate start wherein the player starts with a modified Lampyrid.
-description: Have you ever wanted to start Endless Sky flying something a bit more unique than the typical shuttle, starbarge, or sparrow? Have you dreamed of having a pilot that starts their carreer with an old ship they've been fixing up for the past few years? Well, Lampyrid Start does that. Choosing this starts has your pilot start their career flying a slighly modified version of the Lampyrid, which is a decent balanced transport/freighter with the capacity to be fairly fast compared to others of its class.
+shortDescription: Enables an alternate start wherein the player starts with a modified
+  Lampyrid.
+description: Have you ever wanted to start Endless Sky flying something a bit more
+  unique than the typical shuttle, starbarge, or sparrow? Have you dreamed of having
+  a pilot that starts their carreer with an old ship they've been fixing up for the
+  past few years? Well, Lampyrid Start does that. Choosing this starts has your pilot
+  start their career flying a slighly modified version of the Lampyrid, which is a
+  decent balanced transport/freighter with the capacity to be fairly fast compared
+  to others of its class.
 url: https://github.com/Zitchas/ES_Lampyrid_Start/releases/download/v1.6/Z_Lampyrid_Start.release.v1.6.zip
 iconUrl: https://raw.githubusercontent.com/Zitchas/ES_Lampyrid_Start/v1.6/icon.png
 autoupdate:
   type: tag
-  update_url: https://github.com/Zitchas/ES_Lampyrid_Start/releases/download/$version/Z_Lampyrid_Start.release.$version.zip
+  update_url: https://github.com/Zitchas/ES_Lampyrid_Start
   iconUrl: https://raw.githubusercontent.com/Zitchas/ES_Lampyrid_Start/$version/icon.png

--- a/scripts/autoupdate.py
+++ b/scripts/autoupdate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Check whether a new plug-in version exists. When one is found, updates the manifest according to `autoupdate`.
 # Usage:

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Checks if `url` and `iconUrl` (if it exists) are valid
 # Usage: ./check_urls.py manifests/

--- a/scripts/generate_full_index.py
+++ b/scripts/generate_full_index.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Generates a yaml file containing all plug-ins.
 # Usage: ./generate_table.py manifests/ generated/plugins.yaml

--- a/scripts/generate_table.py
+++ b/scripts/generate_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Generates a markdown file containing a table of all plug-ins.
 # Usage: ./generate_table.py generated/plugins.yaml PLUGINS.md


### PR DESCRIPTION
Dockerfile environment
----------------------

<details><summary><b>Dockerfile used (click to expand)</b></summary>

---

```dockerfile
FROM ubuntu:20.04

ENV DEBIAN_FRONTEND=noninteractive

RUN set -ex; \
apt-get update; \
apt-get install -y git python3 python3.8-venv

RUN set -ex; \
yes | adduser ci-user;

USER ci-user
```

</details>

---

Replicating CI environment
--------------------------

With the `Dockerfile` at the root of the repository I built out the local dev environment.

    docker build -t esci .

I then created a local development environment inside of a Docker container.

    docker run -it --rm -v "${PWD}:${PWD}" -w "${PWD}" --init esci

Install dependencies.

    python3 -m venv .venv
    source .venv/bin/activate
    pip3 install setuptools wheel yq

Once inside of the container I was able to replicate an error.

    ./scripts/autoupdate.py 'manifests/Z Lampyrid Start.yaml'

Bugfix
------

Two bugs:

- The above returned an error which mentioned `update_url` is not a valid Git repository.  So I fixed it and verified it works again for tags.
- Python scripts were broken inside of Python virtualenv.  So I updated the shebang to be compatible with Python virtualenv.