### PR TITLE
Bugfix updating versioned tags

### DIFF
--- a/scripts/autoupdate.py
+++ b/scripts/autoupdate.py
@@ -12,48 +12,34 @@ import dulwich.porcelain
 import re
 import semver
 
-BASEVERSION = re.compile(
-    r"""[vV]?
-        (?P<major>0|[1-9]\d*)
-        (\.
-        (?P<minor>0|[1-9]\d*)
-        (\.
-            (?P<patch>0|[1-9]\d*)
-        )?
-        )?
-    """,
-    re.VERBOSE,
-)
 
 
-def coerce(version):
+BASEVERSION = r'^[vV]?((\.?[0-9]+)+)$'
+
+def get_latest_versioned_tag_from_refs(refs):
     """
-    Stolen from the python-semver docs.
+    Given a list of refs (refs/tags/*) containing version numbers with or
+    without v prefix.  This function will discover the highest version and
+    return the tag name ($name in refs/tags/$name) of the highest version
+    number.
 
-    Convert an incomplete version string into a semver-compatible VersionInfo
-    object
-
-    * Tries to detect a "basic" version string (``major.minor.patch``).
-    * If not enough components can be found, missing components are
-        set to zero to obtain a valid semver version.
-
-    :param str version: the version string to convert
-    :return: a tuple with a :class:`VersionInfo` instance (or ``None``
-        if it's not a version) and the rest of the string which doesn't
-        belong to a basic version.
-    :rtype: tuple(:class:`VersionInfo` | None, str)
+    This function supports versions containing a mixed list of v prefix or pure
+    numbers.  For example, versions ['v1.2', '1.0.0', 'v2.5'] will find v2.5
+    tag name to be the highest version.
     """
-    match = BASEVERSION.search(version)
-    if not match:
-        return (None, version)
-
-    ver = {
-        key: 0 if value is None else value for key, value in match.groupdict().items()
-    }
-    ver = semver.VersionInfo(**ver)
-    rest = match.string[match.end() :]  # noqa:E203
-    return ver, rest
-
+    # remove refs/tags/ prefix (other refs will exist but will be filtered out
+    # in the next step
+    tags=list(map(lambda x: x.replace('refs/tags/', ''), refs))
+    # filter out only valid version numbers (optional v prefix with a set of
+    # numbers separated by periods)
+    tags=list(filter(lambda x: re.match(BASEVERSION, x), tags))
+    # Sort list from lowest to highest version (last item is highest version)
+    # Converts each version number into a list of ints and compares the lists
+    # for ordered integers.  The end result is the same list of tag names but
+    # sorted according to version number.
+    tags.sort(key=lambda tag: list(map(int,  re.match(BASEVERSION, tag).group(1).split('.'))))
+    # return the highest version which is the last item in list
+    return tags[-1]
 
 def ls_remote(url):
     byte_dict = dulwich.porcelain.ls_remote(url)
@@ -73,35 +59,9 @@ def get_latest_version(au_type, au_url, au_branch):
 
     if au_type == "tag":
         refs = ls_remote(au_url)
-        versions = []
-        for ref in refs:
-            if ref.startswith("refs/tags/"):
-                tag = ref.replace("refs/tags/", "")
-
-                # Remove dereferencing syntax, see https://stackoverflow.com/a/15472310/7653274
-                if tag.endswith("^{}"):
-                    tag = tag[:-3]
-
-                # Try to parse the tag as-is
-                if semver.VersionInfo.isvalid(tag):
-                    parsed = semver.VersionInfo.parse(tag)
-                # Strip away a leading `v`, perhaps?
-                elif tag.startswith("v") and semver.VersionInfo.isvalid(tag[1:]):
-                    parsed = semver.VersionInfo.parse(tag[1:])
-                # Or `v.`?
-                elif tag.startswith("v.") and semver.VersionInfo.isvalid(tag[2:]):
-                    parsed = semver.VersionInfo.parse(tag[2:])
-                # Fine, fall back to the method that only parses MAJOR.MINOR.PATCH
-                else:
-                    parsed = coerce(tag)[0]
-
-                # Ignore non-semver versions tags that couldn't be parsed
-                if parsed is not None and parsed is not None:
-                    versions.append((tag, parsed))
-
         # Sort by the second tuple item, which is a parser semver object
         # Then return the associated string (so any prefix that `coerce` stripped doesn't get discarded)
-        return max(versions, key=lambda t: t[1])[0]
+        return get_latest_versioned_tag_from_refs(refs)
 
     raise NotImplementedError("Unknown autoupdate type '%s'" % au_type)
 

--- a/scripts/autoupdate.py
+++ b/scripts/autoupdate.py
@@ -13,8 +13,7 @@ import re
 import semver
 
 
-
-BASEVERSION = r'^[vV]?((\.?[0-9]+)+)$'
+BASEVERSION = r'^[vV]?((\.?[0-9]+)+)(-[a-z]+[0-9]*)?$'
 
 def get_latest_versioned_tag_from_refs(refs):
     """
@@ -24,8 +23,18 @@ def get_latest_versioned_tag_from_refs(refs):
     number.
 
     This function supports versions containing a mixed list of v prefix or pure
-    numbers.  For example, versions ['v1.2', '1.0.0', 'v2.5'] will find v2.5
-    tag name to be the highest version.
+    numbers.  For example, versions ['v1.2', '1.0.0', 'v2.5-alpha1'] will find
+    v2.5-alpha1 tag name to be the highest version.
+
+    Supported version formats where parenthesis show optional values:
+        (v) optional prefix
+        1.0 a version number of dot-separated nubmers
+        (-alpha(1)) optional suffix such as -alpha or -alpha1
+
+    Example:
+        get_latest_versioned_tag_from_refs(['refs/tags/1.2.3-beta2', 'refs/tags/v1.2.3', 'refs/tags/1.1.1', 'refs/tags/1.2.3-alpha', 'refs/tags/1.2.3-beta'])
+    Returns:
+        1.2.3-beta2
     """
     # remove refs/tags/ prefix (other refs will exist but will be filtered out
     # in the next step
@@ -37,7 +46,11 @@ def get_latest_versioned_tag_from_refs(refs):
     # Converts each version number into a list of ints and compares the lists
     # for ordered integers.  The end result is the same list of tag names but
     # sorted according to version number.
-    tags.sort(key=lambda tag: list(map(int,  re.match(BASEVERSION, tag).group(1).split('.'))))
+    #
+    # Two level sorting using a touple inside lambda:
+    #     1st: sort based on version number
+    #     2nd: alphabetical sort based on suffix (if 1st level sort is equal)
+    tags.sort(key=lambda tag: (list(map(int,  re.match(BASEVERSION, tag).group(1).split('.'))), re.match(BASEVERSION, tag).groups()[-1] or ''))
     # return the highest version which is the last item in list
     return tags[-1]
 


### PR DESCRIPTION
All types of tag versions
-------------------------

First thing I did was determine all the ways tags are versioned excluding commit hashes.

```bash
$ grep '^version:' manifests/* | grep -v '[0-9a-f]\{40\}' | sed 's/.*: \?//'
v0.9.14
1.2.0
v0.1.7
1.0.0
v0.2.0
'1.0'
'1.2'
v1.0
'2.2'
v0.9.14
v0.10.10
0.9.14.14.2
0.9.14.7
v0.1.2
v1.6
```

Since we want to support N-depth version numbers it makes sense to sort with a recursive comparison and take the highest version from the sorted list.

Set a new convention for tags
-----------------------------

Rather than trying to coerce version strings out of arbitrary tags we can dictate that version numbers from this point must optionally start with a `v` prefix and be a set of dot-separated numbers.  e.g. `v1.2.3` and `1.2.3` are both considered valid version numbers.

This new convention will not conflict with existing plugins because in the list above containing all types of version numbers you can see that this dictated convention already exists.

Because of this we can simplify the code for discovering versions quite a bit instead of attempting to catch use cases which do not exist (i.e. coerce versions from arbitrary character tags).

Found a problem with Midnight Scrapyard
---------------------------------------

With the `autoupdate.py` script fixed to allow N-depth version numbers, the latest version discovered is `0.19.14.1` (note `0.19` and not `0.9`).  I think this is a mistake and once fixed the `autoupdate.py` script will work normally for Midnight Scrapyard.

I don't think we should code around this mistake but instead ask the Midnight Scrapyard plugin to fix their versions.

Here's a reference to the bad version number (it may 404 later if it gets deleted).

https://github.com/MidnightPlugins/Midnight-Scrapyard/tree/0.19.14.1

Testing the code
----------------

I bootstrapped a Docker-based development environment similar to pull request https://github.com/EndlessSkyCommunity/endless-sky-plugins/pull/120

I then ran the following one-liner to update all projects using the new script.  It worked for all versions as intended.

    find manifests -type f -print0 | xargs -0 -n1 ./scripts/autoupdate.py