### PR TITLE
Add Spacefarer plugin

### DIFF
--- a/manifests/Spacefarer.yaml
+++ b/manifests/Spacefarer.yaml
@@ -1,0 +1,18 @@
+name: Spacefarer
+authors: samrocketman and Airhead
+homepage: https://github.com/samrocketman/Spacefarer
+license: GPL-3.0
+version: b3d3ffa06d931b111435169929f535970152b4a6
+shortDescription: One Jump Drive; No ship capturing; No plundering installed outfits.
+description: As a captain, you're responsible for the lives of your crew.  Loss of
+  life is inevitable in the merciless reaches of space.  You stick to exploration,
+  ferrying, and fleet combat.  If anyone dies, it will be everyone when the ship explodes.  This
+  plugin adds replay value by forcing the player to discover alternate and competing
+  forms of income in order to efficiently obtain a fleet.
+url: https://github.com/samrocketman/Spacefarer/archive/b3d3ffa06d931b111435169929f535970152b4a6.zip
+iconUrl: https://raw.githubusercontent.com/samrocketman/Spacefarer/b3d3ffa06d931b111435169929f535970152b4a6/icon%402x.png
+autoupdate:
+  type: commit
+  branch: main
+  url: https://github.com/samrocketman/Spacefarer/archive/$version.zip
+  iconUrl: https://raw.githubusercontent.com/samrocketman/Spacefarer/$version/icon%402x.png


### PR DESCRIPTION
A new plugin which forces balance into the game by removing ship capturing and looting.  Because Jump drives are so mystical and rare in lore you only get one jump drive during your playthrough (except for when necessary to unblock critical story progression you may get a second Jump Drive).  This means you'll need to build multiple fleets in different regions of space as your universe expands.

- One Jump Drive
- No ship capturing
- No plundering installed outfits

https://github.com/samrocketman/Spacefarer