### PR TITLE
Add Crisis in Management manifest

### DIFF
--- a/manifests/crisis-in-management.yaml
+++ b/manifests/crisis-in-management.yaml
@@ -1,0 +1,17 @@
+name: Crisis in Management
+authors: leklachu
+homepage: https://github.com/leklachu/endless-sky-syndicate
+license: CC-BY-SA-4.0
+version: v0.9
+shortDescription: Alternate start in Syndicate space, with a story parallel to the main plot.
+description: >-
+  Crisis in Management is an alternate start in the Syndicate, the story of a
+  manger who quits managing and start piloting. Leave your failing company and
+  take to the stars to escape repercussions, then find yourself in the
+  background, behind the scenes of Endless Sky's main storyline. Beyond that,
+  the same endless sky awaits.
+url: https://github.com/leklachu/endless-sky-syndicate/releases/download/v0.9/crisis-in-management_v0.9.zip
+iconUrl: https://raw.githubusercontent.com/leklachu/endless-sky-syndicate/master/icon.png
+autoupdate:
+  type: tag
+  url: https://github.com/leklachu/endless-sky-syndicate/releases/download/$version/crisis-in-management_$version.zip


### PR DESCRIPTION
A plugin for an alternate start, as a manager in a Syndicate company who leaves to take to the stars. This launches the player into an alternate story that runs parallel to the Free Worlds plot.

Within the alternate start, the player is excluded from the Free Worlds campaign (which is happening in the background) but otherwise the game remains the same, plus of course this campaign. No change is made to the game in a normal start (except for a small, irrelevant, bonus mission).

https://github.com/leklachu/endless-sky-syndicate