### PR TITLE
Include a description of how to add a plugin to the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ You may also use the [manifest generator](https://endless-sky.github.io/plugin-m
 ### Common issues
 Once you have your manifest ready, take a moment to check the following before opening your PR to ensure it's merged promptly and smoothly:
 1. Are all of your URLs valid? Try copying and pasting them into a web browser to ensure they all point to the locations you expect.
-   * Also, check the autoupdate URLs by inserting the current version and ensure it creates a valid URL
-   * If you have included an iconURL, ensure that it is also correctly versioned
+   * Also, check the autoupdate URLs by inserting the current version and ensure it creates a valid URL.
+   * If you have included an iconURL, ensure that it is also correctly versioned.
 2. Ensure the version listed on your manifest is a real commit/tag. You should be able to find the same commit on your repository that you have listed in the manifest.
 3. Ensure the license you're using is valid, either choose one from the [SPDX list](https://spdx.org/licenses/) or enter ALL-RIGHTS-RESERVED.
     * For open source plugins, it’s recommended to use a license from the [OSI-approved list](https://opensource.org/license).


### PR DESCRIPTION
The ReadMe currently lists the RFC as an example of what the manifest should include, but doesn't provide much detail. 
I've expanded it a bit to give a more complete guide on how to add a new plugin to the index, including:

- Links to the GitHub documentation on creating a new PR
- Specifies proper naming and extension for the manifest file
- Links to the RFC for valid manifest formatting
- Links to examples for a valid manifest
- Includes a section on common mistakes and how to avoid them.

Bit of a stopgap measure as I still think moving away from the PR process entirely is probably a good idea, but in the meantime, this should hopefully make it a bit easier for first-time contributors to understand what they will need to do in order to add a plugin to the index. 