### PR TITLE
Update buyable_faesmar.yaml

### DIFF
--- a/manifests/buyable_faesmar.yaml
+++ b/manifests/buyable_faesmar.yaml
@@ -1,6 +1,6 @@
 name: Buyable Faes'mar
 authors: kaiboy
-homepage: https://github.com/kaiboyjiang/endless-sky-plugins/tree/main/myplugins/buyable_faesmar
+homepage: https://github.com/kaiboyjiang/endless-sky-plugins?tab=readme-ov-file#buyable_faesmar
 license: CC-BY-SA-4.0
 version: v1.1.0-buyable_faesmar
 shortDescription: Allows you to buy the Faes'mar.


### PR DESCRIPTION
I just discovered that most ES assets are licensed under CC BY-SA 4.0, which requires derivative works (like this one) to be licensed under the same. This PR changes the license of Buyable Faes'mar from All Rights Reserved to CC BY-SA 4.0.